### PR TITLE
LDN-2024: Add Heroku to sponsors; alphabetize

### DIFF
--- a/data/events/2024/london/main.yml
+++ b/data/events/2024/london/main.yml
@@ -109,13 +109,15 @@ organizer_email: "london@devopsdays.org" # Put your organizer email address here
 sponsors:
   # platinum sponsors
   # gold sponsors
-  - id: eficode
-    level: gold
   - id: cloudsmith
     level: gold
   - id: contrast_security
     level: gold
+  - id: eficode
+    level: gold
   - id: elastic
+    level: gold
+  - id: heroku
     level: gold
   # silver sponsors
   - id: devex-connect


### PR DESCRIPTION
- "Heroku (a Salesforce company)" sponsored us at Gold level.